### PR TITLE
[BUG] 나의 토픽 > 스티커 수정시 드래그 핸들, 추가버튼이 모달 바깥에 노출되는 이슈 대응

### DIFF
--- a/apps/web/src/components/(with-side-bar)/topic/sticker/topic-sticker-detail-modal.tsx
+++ b/apps/web/src/components/(with-side-bar)/topic/sticker/topic-sticker-detail-modal.tsx
@@ -43,7 +43,7 @@ export default function TopicStickerDetailModal() {
         }}
         onMouseDown={onMouseDown}
       >
-        <div className="bg-background size-4/5 space-y-4 rounded-2xl p-8">
+        <div className="bg-background size-4/5 space-y-4 rounded-2xl px-16 py-8">
           <div className="flex items-center justify-between">
             <button onClick={onRouteToDetail}>
               <MoveDiagonal2 size={20} />


### PR DESCRIPTION
## 설명
나의 토픽 > 스티커 수정시 드래그 핸들, 추가버튼이 모달 바깥에 노출 되는 이슈가 있어 이를 대응합니다.

## 작업내용
- 모달 내부에 x 패딩값을 주어 전체 모달의 넓이를 넓히는 방식으로대응합니다.

## 참고(선택)
- 피그마 시안에 권한이 없어 임의의 값으로 x패딩 값을 설정했습니다. 방향성만 봐주시고, 세부 디자인이 반영 되어야 한다면 커밋 하나 더 쌓아 놓도록 하겠습니다.

## 스크린샷(선택)
<img width="1430" height="749" alt="image" src="https://github.com/user-attachments/assets/3703facf-405b-41d0-899e-ecfdb0e8924f" />


## 메모(선택)
- 모달의 패딩 값이 고정되어야 한다면 다른 방향으로 작업 진행하도록 하겠습니다.
- 코드 변경은 단순하지만 온보딩 중이라 브랜치 네이밍, 커밋 등 컨벤션에 관한것도 같이 리뷰해주시면 감사하겠습니다. 

## 연관 이슈

resolve #45

