### PR TITLE
[FEATURE] 우클릭 시 복제 기능 구현

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -95,3 +95,10 @@ div.customHandle {
   filter: blur(120px);
   opacity: 0.9;
 }
+
+@utility triangle {
+  background-color: rgba(0, 0, 0, 0.55);
+  width: 20px;
+  height: 12px;
+  clip-path: polygon(45% 0%, 55% 0%, 100% 100%, 0% 100%);
+}

--- a/apps/web/src/components/(with-side-bar)/library/content-sidebar.tsx
+++ b/apps/web/src/components/(with-side-bar)/library/content-sidebar.tsx
@@ -6,7 +6,8 @@ import { useSearchParams } from "next/navigation";
 import ResizeBar from "@/components/common/resize-bar";
 import { CATEGORY } from "@/constants/category";
 import { CONTENT } from "@/constants/content";
-import { invalidateMany } from "@/lib/tanstack";
+import { TOPIC } from "@/constants/topic";
+import { invalidateQueries } from "@/lib/tanstack";
 import { useRemoveContentById, useUpdateContent } from "@/lib/tanstack/mutation/content";
 import { useGetCategories } from "@/lib/tanstack/query/category";
 import { useGetContentById } from "@/lib/tanstack/query/content";
@@ -77,11 +78,11 @@ export default function ContentSidebar() {
       await updateContent(body, {
         onSuccess: () => {
           setIsEditing(false);
-          invalidateMany([
-            [CONTENT.GET_CONTENT_BY_ID, selectedContentId],
-            [CONTENT.GET_CATEGORY_CONTENT_BY_ID, categoryId],
-            [CATEGORY.GET_CATEGORIES],
-          ]);
+          invalidateQueries([CONTENT.GET_CONTENT_BY_ID, selectedContentId]);
+          invalidateQueries([CONTENT.GET_CATEGORY_CONTENT_BY_ID, categoryId]);
+          invalidateQueries([CATEGORY.GET_CATEGORIES]);
+          invalidateQueries([TOPIC.GET_ALL_CONTENTS]);
+          invalidateQueries([TOPIC.GET_TOPIC_BOARD_BY_ID]);
         },
       });
     }
@@ -104,11 +105,11 @@ export default function ContentSidebar() {
     await removeContent(selectedContentId, {
       onSuccess: () => {
         onClose();
-        invalidateMany([
-          [CONTENT.GET_CONTENT_BY_ID, selectedContentId],
-          [CONTENT.GET_CATEGORY_CONTENT_BY_ID, categoryId],
-          [CATEGORY.GET_CATEGORIES],
-        ]);
+        invalidateQueries([CONTENT.GET_CONTENT_BY_ID, selectedContentId]);
+        invalidateQueries([CONTENT.GET_CATEGORY_CONTENT_BY_ID, categoryId]);
+        invalidateQueries([CATEGORY.GET_CATEGORIES]);
+        invalidateQueries([TOPIC.GET_ALL_CONTENTS]);
+        invalidateQueries([TOPIC.GET_TOPIC_BOARD_BY_ID]);
       },
     });
   };

--- a/apps/web/src/components/(with-side-bar)/topic/context-menu-provider.tsx
+++ b/apps/web/src/components/(with-side-bar)/topic/context-menu-provider.tsx
@@ -117,7 +117,7 @@ export default function ContextMenuProvider({
   );
 
   useEffect(() => {
-    if (!open) return;
+    if (!isContextMenuOpen) return;
 
     window.addEventListener("keydown", onKeyDown);
 

--- a/apps/web/src/components/(with-side-bar)/topic/context-menu-provider.tsx
+++ b/apps/web/src/components/(with-side-bar)/topic/context-menu-provider.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 
 import {
   ContextMenu,
@@ -7,16 +7,14 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/common/context-menu";
+import { TopicContext } from "@/context/topic-context";
 import { useCreateContent } from "@/lib/tanstack/mutation/topic-content";
 import type { CategoryContentDTO } from "@linkyboard/types";
 import type { Node } from "@xyflow/react";
 
 interface ContextMenuProviderProps {
   children: React.ReactNode;
-  id: string;
-  nodes: Node[];
   isTriggerDisabled: boolean;
-  selectedNodeIds: string[];
 }
 
 const isMac = typeof window !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
@@ -28,11 +26,15 @@ const onEscapeContextMenu = () => {
 
 export default function ContextMenuProvider({
   children,
-  nodes,
-  id,
   isTriggerDisabled,
-  selectedNodeIds,
 }: ContextMenuProviderProps) {
+  const topicContext = useContext(TopicContext);
+  if (!topicContext) {
+    throw new Error("TopicContext not found");
+  }
+
+  const { id, nodes, selectedNodeIds } = topicContext;
+
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
 
   const { mutateAsync: createContent } = useCreateContent(id);

--- a/apps/web/src/components/(with-side-bar)/topic/context-menu-provider.tsx
+++ b/apps/web/src/components/(with-side-bar)/topic/context-menu-provider.tsx
@@ -7,10 +7,16 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/common/context-menu";
+import { useCreateContent } from "@/lib/tanstack/mutation/topic-content";
+import type { CategoryContentDTO } from "@linkyboard/types";
+import type { Node } from "@xyflow/react";
 
 interface ContextMenuProviderProps {
   children: React.ReactNode;
+  id: string;
+  nodes: Node[];
   isTriggerDisabled: boolean;
+  selectedNodeIds: string[];
 }
 
 const isMac = typeof window !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
@@ -22,34 +28,49 @@ const onEscapeContextMenu = () => {
 
 export default function ContextMenuProvider({
   children,
+  nodes,
+  id,
   isTriggerDisabled,
+  selectedNodeIds,
 }: ContextMenuProviderProps) {
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
 
-  const onDuplicate = () => {
-    console.log("Duplicate 실행");
-    // 여기에 Duplicate 로직 추가
-  };
+  const { mutateAsync: createContent } = useCreateContent(id);
 
-  const onLink = () => {
+  const onDuplicate = useCallback(() => {
+    selectedNodeIds.forEach(async (nodeId) => {
+      const node: Node | undefined = nodes.find((node) => node.id === nodeId);
+      if (!node) return;
+      const { item } = node.data as { item: CategoryContentDTO };
+
+      await createContent({
+        topicId: id,
+        contentId: item.id,
+        posX: node.position.x + 100,
+        posY: node.position.y + 100,
+      });
+    });
+  }, [id, createContent, selectedNodeIds, nodes]);
+
+  const onLink = useCallback(() => {
     console.log("Link 실행");
     // 여기에 Link 로직 추가
-  };
+  }, []);
 
-  const onUnlink = () => {
+  const onUnlink = useCallback(() => {
     console.log("Unlink 실행");
     // 여기에 Unlink 로직 추가
-  };
+  }, []);
 
-  const onSummary = () => {
+  const onSummary = useCallback(() => {
     console.log("Summary 실행");
     // 여기에 Summary 로직 추가
-  };
+  }, []);
 
-  const onDelete = () => {
+  const onDelete = useCallback(() => {
     console.log("Delete 실행");
     // 여기에 Delete 로직 추가
-  };
+  }, []);
 
   const onCloseContextMenu = useCallback(() => {
     setIsContextMenuOpen(false);
@@ -90,7 +111,7 @@ export default function ContextMenuProvider({
           break;
       }
     },
-    [onCloseContextMenu]
+    [onCloseContextMenu, onDuplicate, onLink, onUnlink, onSummary, onDelete]
   );
 
   useEffect(() => {

--- a/apps/web/src/components/(with-side-bar)/topic/react-flow-canvas.tsx
+++ b/apps/web/src/components/(with-side-bar)/topic/react-flow-canvas.tsx
@@ -1,39 +1,18 @@
 "use client";
 
-import { useMemo } from "react";
+import { useContext, useMemo } from "react";
 
+import { TopicContext } from "@/context/topic-context";
 import { useCreateContent } from "@/lib/tanstack/mutation/topic-content";
 import { Spinner } from "@linkyboard/components";
 import type { CategoryContentDTO } from "@linkyboard/types";
-import type { Connection, Edge, Node, NodeProps, NodeTypes } from "@xyflow/react";
-import {
-  Background,
-  type OnEdgesChange,
-  type OnNodesChange,
-  ReactFlow,
-  ReactFlowProvider,
-  useReactFlow,
-} from "@xyflow/react";
+import type { NodeProps, NodeTypes } from "@xyflow/react";
+import { Background, ReactFlow, ReactFlowProvider, useReactFlow } from "@xyflow/react";
 
 import { AlertTriangle } from "lucide-react";
 
 import ContextMenuProvider from "./context-menu-provider";
 import Sticker from "./sticker";
-
-interface ReactFlowCanvasProps {
-  isLoading: boolean;
-  isTopicError: boolean;
-  isNotFoundError: boolean;
-  id: string;
-  nodes: Node[];
-  edges: Edge[];
-  selectedNodeIds: string[];
-  onNodesChange: OnNodesChange<Node>;
-  onEdgesChange: OnEdgesChange<Edge>;
-  onConnect: (params: Connection) => void;
-  onEdgeClick: (e: React.MouseEvent, edge: Edge) => void;
-  onNodeSelect: (nodeId: string) => void;
-}
 
 const connectionLineStyle = {
   stroke: "#b1b1b7",
@@ -46,28 +25,35 @@ const defaultEdgeOptions = {
   },
 };
 
-export default function ReactFlowCanvas(props: ReactFlowCanvasProps) {
+export default function ReactFlowCanvas() {
   return (
     <ReactFlowProvider>
-      <FlowCanvas {...props} />
+      <FlowCanvas />
     </ReactFlowProvider>
   );
 }
 
-function FlowCanvas({
-  isLoading,
-  isTopicError,
-  isNotFoundError,
-  id,
-  nodes,
-  edges,
-  selectedNodeIds,
-  onNodesChange,
-  onEdgesChange,
-  onConnect,
-  onEdgeClick,
-  onNodeSelect,
-}: ReactFlowCanvasProps) {
+function FlowCanvas() {
+  const topicContext = useContext(TopicContext);
+  if (!topicContext) {
+    throw new Error("TopicContext not found");
+  }
+
+  const {
+    isLoading,
+    isTopicError,
+    isNotFoundError,
+    id,
+    nodes,
+    edges,
+    selectedNodeIds,
+    onNodesChange,
+    onEdgesChange,
+    onConnect,
+    onEdgeClick,
+    onNodeSelect,
+  } = topicContext;
+
   const { screenToFlowPosition } = useReactFlow();
   const { mutateAsync: createContent } = useCreateContent(id);
 
@@ -114,12 +100,7 @@ function FlowCanvas({
   };
 
   return (
-    <ContextMenuProvider
-      id={id}
-      nodes={nodes}
-      isTriggerDisabled={isTriggerDisabled}
-      selectedNodeIds={selectedNodeIds}
-    >
+    <ContextMenuProvider isTriggerDisabled={isTriggerDisabled}>
       <div
         className="relative flex-1 overflow-hidden rounded-r-lg border border-l-0"
         onDragOver={onDragOver}
@@ -140,13 +121,13 @@ function FlowCanvas({
           <ReactFlow
             nodes={nodes}
             edges={edges}
+            nodeTypes={nodeTypes}
+            connectionLineStyle={connectionLineStyle}
+            defaultEdgeOptions={defaultEdgeOptions}
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             onConnect={onConnect}
             onEdgeClick={onEdgeClick}
-            nodeTypes={nodeTypes}
-            connectionLineStyle={connectionLineStyle}
-            defaultEdgeOptions={defaultEdgeOptions}
           >
             <Background />
           </ReactFlow>

--- a/apps/web/src/components/(with-side-bar)/topic/react-flow-canvas.tsx
+++ b/apps/web/src/components/(with-side-bar)/topic/react-flow-canvas.tsx
@@ -61,11 +61,11 @@ function FlowCanvas({
   id,
   nodes,
   edges,
+  selectedNodeIds,
   onNodesChange,
   onEdgesChange,
   onConnect,
   onEdgeClick,
-  selectedNodeIds,
   onNodeSelect,
 }: ReactFlowCanvasProps) {
   const { screenToFlowPosition } = useReactFlow();
@@ -114,7 +114,12 @@ function FlowCanvas({
   };
 
   return (
-    <ContextMenuProvider isTriggerDisabled={isTriggerDisabled}>
+    <ContextMenuProvider
+      id={id}
+      nodes={nodes}
+      isTriggerDisabled={isTriggerDisabled}
+      selectedNodeIds={selectedNodeIds}
+    >
       <div
         className="relative flex-1 overflow-hidden rounded-r-lg border border-l-0"
         onDragOver={onDragOver}

--- a/apps/web/src/components/(with-side-bar)/topic/sticker/block-note.tsx
+++ b/apps/web/src/components/(with-side-bar)/topic/sticker/block-note.tsx
@@ -9,7 +9,7 @@ import { useRouter } from "next/navigation";
 
 import { CUSTOM_STICKER } from "@/constants/custom-sticker";
 import { TOPIC } from "@/constants/topic";
-import { invalidateMany, invalidateQueries } from "@/lib/tanstack";
+import { invalidateQueries } from "@/lib/tanstack";
 import {
   useRemoveCustomSticker,
   useUpdateCustomSticker,
@@ -161,10 +161,8 @@ export default function BlockNote({ topicId, stickerId }: BlockNoteProps) {
     await removeCustomSticker(stickerId, {
       onSuccess: () => {
         successToast("스티커가 성공적으로 삭제되었어요.");
-        invalidateMany([
-          [TOPIC.GET_TOPIC_BOARD_BY_ID, topicId],
-          [CUSTOM_STICKER.GET_CUSTOM_STICKER_BY_ID, stickerId],
-        ]);
+        invalidateQueries([TOPIC.GET_TOPIC_BOARD_BY_ID, topicId]);
+        invalidateQueries([CUSTOM_STICKER.GET_CUSTOM_STICKER_BY_ID, stickerId]);
         if (!topicStore.isOpen) {
           router.back();
         }

--- a/apps/web/src/components/(with-side-bar)/topic/sticker/content-sticker.tsx
+++ b/apps/web/src/components/(with-side-bar)/topic/sticker/content-sticker.tsx
@@ -18,6 +18,7 @@ interface ContentStickerProps {
   onSelect: (nodeId: string) => void;
   height?: number;
   topicId: string;
+  topicContentId: number;
 }
 
 const contentType = {
@@ -49,6 +50,7 @@ export default function ContentSticker({
   onSelect,
   height,
   topicId,
+  topicContentId,
 }: ContentStickerProps) {
   const { mutateAsync: updateContent } = useUpdateContent({
     onSuccess: () => {
@@ -113,7 +115,7 @@ export default function ContentSticker({
                 ? "bg-primary text-white"
                 : "bg-muted text-muted-foreground hover:bg-primary hover:text-white"
             )}
-            onClick={() => onSelect(`content-${item.id}`)}
+            onClick={() => onSelect(`content-${topicContentId}`)}
             aria-label={isSelected ? "선택 해제" : "선택"}
           >
             <Check size={16} />

--- a/apps/web/src/components/(with-side-bar)/topic/sticker/content-sticker.tsx
+++ b/apps/web/src/components/(with-side-bar)/topic/sticker/content-sticker.tsx
@@ -1,15 +1,23 @@
+import { useState } from "react";
+
+import { CONTENT } from "@/constants/content";
+import { TOPIC } from "@/constants/topic";
+import { invalidateQueries } from "@/lib/tanstack";
+import { useUpdateContent } from "@/lib/tanstack/mutation/content";
 import { useContentSidebarStore } from "@/lib/zustand/content-sidebar";
-import { Button } from "@linkyboard/components";
+import { Button, errorToast } from "@linkyboard/components";
+import { useOutsideClick } from "@linkyboard/hooks";
 import type { CategoryContentDTO } from "@linkyboard/types";
 import { cn } from "@linkyboard/utils";
 
-import { Check, Edit, FileText, Globe, Youtube } from "lucide-react";
+import { Check, Edit, Ellipsis, FileText, Globe, Youtube } from "lucide-react";
 
 interface ContentStickerProps {
   item: CategoryContentDTO;
   isSelected: boolean;
   onSelect: (nodeId: string) => void;
   height?: number;
+  topicId: string;
 }
 
 const contentType = {
@@ -26,17 +34,49 @@ const contentType = {
     color: "text-gray-500",
   },
 };
+const colors = [
+  "oklch(1 0 0)",
+  "oklch(0.7922 0.12 20.09)",
+  "oklch(0.9525 0.1084 100.83)",
+  "oklch(0.9318 0.1464 136.17)",
+  "oklch(0.7859 0.1077 267.59)",
+  "oklch(0.7831 0.1506 310.86)",
+];
 
 export default function ContentSticker({
   item,
   isSelected,
   onSelect,
   height,
+  topicId,
 }: ContentStickerProps) {
+  const { mutateAsync: updateContent } = useUpdateContent({
+    onSuccess: () => {
+      invalidateQueries([CONTENT.GET_CONTENT_BY_ID, item.id.toString()]);
+      invalidateQueries([TOPIC.GET_TOPIC_BOARD_BY_ID, topicId]);
+    },
+    onError: (error) => {
+      errorToast("색상 변경에 실패했어요.");
+      console.error(error);
+    },
+  });
+  const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
+  const [colorPickerContainerRef] = useOutsideClick<HTMLDivElement>(() => {
+    setIsColorPickerOpen(false);
+  });
+
   const onOpen = useContentSidebarStore((state) => state.onOpen);
 
   const onEditTopic = () => {
     onOpen(item.id);
+  };
+
+  const onSelectColor = (color: string) => {
+    setIsColorPickerOpen(false);
+    updateContent({
+      ...item,
+      color,
+    });
   };
 
   const shouldShowMemo = height && height >= 300;
@@ -83,17 +123,45 @@ export default function ContentSticker({
 
       <p className="text-muted-foreground mb-4 line-clamp-3 text-sm">{item.summary}</p>
 
-      <div className="flex flex-wrap gap-1">
-        {item.tags.slice(0, 3).map((tag: string) => (
-          <span key={tag} className="bg-muted text-muted-foreground rounded px-2 py-1 text-xs">
-            {tag}
-          </span>
-        ))}
-        {item.tags.length > 3 && (
-          <span className="bg-muted text-muted-foreground rounded px-2 py-1 text-xs">
-            +{item.tags.length - 3}
-          </span>
-        )}
+      <div className="flex items-center justify-between">
+        <div className="flex flex-wrap gap-1">
+          {item.tags.slice(0, 3).map((tag: string) => (
+            <span key={tag} className="bg-muted text-muted-foreground rounded px-2 py-1 text-xs">
+              {tag}
+            </span>
+          ))}
+          {item.tags.length > 3 && (
+            <span className="bg-muted text-muted-foreground rounded px-2 py-1 text-xs">
+              +{item.tags.length - 3}
+            </span>
+          )}
+        </div>
+        <div className="relative h-full">
+          <button
+            className="h-full text-gray-300"
+            onClick={() => setIsColorPickerOpen(!isColorPickerOpen)}
+          >
+            <Ellipsis />
+          </button>
+          {isColorPickerOpen && (
+            <div
+              ref={colorPickerContainerRef}
+              className="absolute right-0 top-full mt-2 translate-y-1/2"
+            >
+              <div className="triangle absolute right-2 top-0 -translate-y-full" />
+              <div className="relative left-2 flex gap-4 rounded-[12px] bg-black/55 p-3">
+                {colors.map((color) => (
+                  <button
+                    key={color}
+                    className="size-10 rounded-full border-4 border-white"
+                    style={{ backgroundColor: color }}
+                    onClick={() => onSelectColor(color)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
 
       {/* 스티커가 충분히 클 때만 메모를 보여줌 */}

--- a/apps/web/src/components/(with-side-bar)/topic/sticker/index.tsx
+++ b/apps/web/src/components/(with-side-bar)/topic/sticker/index.tsx
@@ -30,6 +30,7 @@ interface StickerProps extends NodeProps {
 interface NodeData {
   nodeContent: StickerType;
   item: TopicDTO | CategoryContentDTO;
+  color: string | null;
 }
 
 const stickerStyle = {
@@ -187,6 +188,7 @@ export default function Sticker(props: StickerProps) {
         minHeight: "13.75rem",
         width: props.width,
         height: props.height,
+        backgroundColor: nodeData.color ?? undefined,
       }}
     >
       <NodeResizer
@@ -270,6 +272,7 @@ export default function Sticker(props: StickerProps) {
           isSelected={props.isSelected}
           onSelect={props.onSelect}
           height={props.height}
+          topicId={props.topicId}
         />
       ) : (
         <UserSticker item={nodeData.item as TopicDTO} topicId={props.topicId} />

--- a/apps/web/src/components/(with-side-bar)/topic/sticker/index.tsx
+++ b/apps/web/src/components/(with-side-bar)/topic/sticker/index.tsx
@@ -31,6 +31,7 @@ interface NodeData {
   nodeContent: StickerType;
   item: TopicDTO | CategoryContentDTO;
   color: string | null;
+  topicContentId: number | null;
 }
 
 const stickerStyle = {
@@ -98,9 +99,10 @@ export default function Sticker(props: StickerProps) {
           await updateTopicPosition(body);
           break;
         case "content":
+          if (!nodeData.topicContentId) return;
           await updateContentPosition({
             ...body,
-            contentId: nodeData.item.id,
+            topicContentId: nodeData.topicContentId,
           });
           break;
         case "custom_sticker":
@@ -153,9 +155,10 @@ export default function Sticker(props: StickerProps) {
           await updateTopicSize(body);
           break;
         case "content":
+          if (!nodeData.topicContentId) return;
           await updateContentSize({
             ...body,
-            contentId: nodeData.item.id,
+            topicContentId: nodeData.topicContentId,
           });
           break;
         case "custom_sticker":
@@ -266,13 +269,14 @@ export default function Sticker(props: StickerProps) {
 
       {nodeData.nodeContent === "topic" ? (
         <TopicSticker item={nodeData.item as TopicDTO} />
-      ) : nodeData.nodeContent === "content" ? (
+      ) : nodeData.nodeContent === "content" && nodeData.topicContentId !== null ? (
         <ContentSticker
           item={nodeData.item as CategoryContentDTO}
           isSelected={props.isSelected}
           onSelect={props.onSelect}
           height={props.height}
           topicId={props.topicId}
+          topicContentId={nodeData.topicContentId}
         />
       ) : (
         <UserSticker item={nodeData.item as TopicDTO} topicId={props.topicId} />

--- a/apps/web/src/components/(with-side-bar)/topic/sticker/user-sticker.tsx
+++ b/apps/web/src/components/(with-side-bar)/topic/sticker/user-sticker.tsx
@@ -13,7 +13,12 @@ import { Edit, Sticker, Trash2 } from "lucide-react";
 
 import RemoveUserStickerDialog from "./remove-user-sticker-dialog";
 
-export default function UserSticker({ item, topicId }: { item: TopicDTO; topicId: string }) {
+interface UserStickerProps {
+  item: TopicDTO;
+  topicId: string;
+}
+
+export default function UserSticker({ item, topicId }: UserStickerProps) {
   const topicStore = useTopicStore();
 
   const onEditTopic = () => {

--- a/apps/web/src/context/topic-context.tsx
+++ b/apps/web/src/context/topic-context.tsx
@@ -1,0 +1,20 @@
+import { createContext } from "react";
+
+import type { Connection, Edge, Node, OnEdgesChange, OnNodesChange } from "@xyflow/react";
+
+interface TopicContextProps {
+  isLoading: boolean;
+  isTopicError: boolean;
+  isNotFoundError: boolean;
+  id: string;
+  nodes: Node[];
+  edges: Edge[];
+  selectedNodeIds: string[];
+  onNodesChange: OnNodesChange<Node>;
+  onEdgesChange: OnEdgesChange<Edge>;
+  onConnect: (params: Connection) => void;
+  onEdgeClick: (e: React.MouseEvent, edge: Edge) => void;
+  onNodeSelect: (nodeId: string) => void;
+}
+
+export const TopicContext = createContext<TopicContextProps | null>(null);

--- a/apps/web/src/lib/tanstack/index.ts
+++ b/apps/web/src/lib/tanstack/index.ts
@@ -13,7 +13,3 @@ export const queryClient = new QueryClient({
 export const invalidateQueries = (queryKey: QueryKey) => {
   queryClient.invalidateQueries({ queryKey });
 };
-
-export const invalidateMany = (queryKeys: QueryKey[]) => {
-  return Promise.all(queryKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey })));
-};

--- a/apps/web/src/lib/tanstack/mutation/content.ts
+++ b/apps/web/src/lib/tanstack/mutation/content.ts
@@ -1,5 +1,10 @@
+import type { ContentDetailDTO } from "@/models/content";
 import { removeContentById, updateContent } from "@/services/content";
+import type { BaseResponseDTO } from "@linkyboard/types";
+import type { UseMutationOptions } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
+
+import type { HTTPError } from "ky";
 
 export const useRemoveContentById = () => {
   return useMutation({
@@ -7,8 +12,11 @@ export const useRemoveContentById = () => {
   });
 };
 
-export const useUpdateContent = () => {
+export const useUpdateContent = (
+  options?: UseMutationOptions<BaseResponseDTO<unknown>, HTTPError, ContentDetailDTO>
+) => {
   return useMutation({
     mutationFn: updateContent,
+    ...options,
   });
 };

--- a/apps/web/src/models/content.ts
+++ b/apps/web/src/models/content.ts
@@ -10,4 +10,5 @@ export interface ContentDetailDTO {
   tags: string[];
   type: ContentType;
   category: string;
+  color: string;
 }

--- a/apps/web/src/page/topic/[id]/index.tsx
+++ b/apps/web/src/page/topic/[id]/index.tsx
@@ -50,11 +50,11 @@ export default function TopicBoardPage({ id, type }: TopicBoardPageProps) {
 
   const isNotFoundError = (!isLoading && error?.message.includes("404")) || false;
 
-  const onNodeSelect = (nodeId: string) => {
+  const onNodeSelect = useCallback((nodeId: string) => {
     setSelectedNodeIds((prev) =>
       prev.includes(nodeId) ? prev.filter((id) => id !== nodeId) : [...prev, nodeId]
     );
-  };
+  }, []);
 
   const onConnect = useCallback(
     async (params: Connection) => {

--- a/apps/web/src/page/topic/[id]/index.tsx
+++ b/apps/web/src/page/topic/[id]/index.tsx
@@ -10,6 +10,7 @@ import RemoveContentButton from "@/components/(with-side-bar)/topic/remove-conte
 import SummarizeDialog from "@/components/(with-side-bar)/topic/summarize-dialog";
 import SearchHeader from "@/components/common/search-header";
 import type { ContentTypeOptions } from "@/constants/content";
+import { TopicContext } from "@/context/topic-context";
 import { useCreateConnection, useRemoveConnection } from "@/lib/tanstack/mutation/connection";
 import { useGetTopicBoardById } from "@/lib/tanstack/query/topic";
 import { infoToast, Spinner } from "@linkyboard/components";
@@ -145,20 +146,24 @@ export default function TopicBoardPage({ id, type }: TopicBoardPageProps) {
       <div className="flex h-[calc(100vh-130px)]">
         <AddContent id={id} type={type} />
 
-        <ReactFlowCanvas
-          isLoading={isLoading}
-          isTopicError={isError}
-          isNotFoundError={isNotFoundError}
-          id={id}
-          nodes={nodes}
-          edges={edges}
-          selectedNodeIds={selectedNodeIds}
-          onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
-          onConnect={onConnect}
-          onEdgeClick={onEdgeClick}
-          onNodeSelect={onNodeSelect}
-        />
+        <TopicContext.Provider
+          value={{
+            isLoading,
+            isTopicError: isError,
+            isNotFoundError,
+            id,
+            nodes,
+            edges,
+            selectedNodeIds,
+            onNodesChange,
+            onEdgesChange,
+            onConnect,
+            onEdgeClick,
+            onNodeSelect,
+          }}
+        >
+          <ReactFlowCanvas />
+        </TopicContext.Provider>
       </div>
     </div>
   );

--- a/apps/web/src/services/topic-content.ts
+++ b/apps/web/src/services/topic-content.ts
@@ -4,7 +4,7 @@ import { clientApi } from ".";
 
 export const updateContentPosition = async (props: {
   topicId: string;
-  contentId: number;
+  topicContentId: number;
   posX: number;
   posY: number;
 }): Promise<BaseResponseDTO<unknown>> => {
@@ -14,7 +14,7 @@ export const updateContentPosition = async (props: {
 
 export const updateContentSize = async (props: {
   topicId: string;
-  contentId: number;
+  topicContentId: number;
   width: number;
   height: number;
 }): Promise<BaseResponseDTO<unknown>> => {
@@ -43,7 +43,7 @@ export const removeTopicContentById = async (props: {
   return clientApi
     .delete(`topic-contents/topics/${props.topicId}/contents`, {
       json: {
-        contentIds: props.contentIds,
+        topicContentIds: props.contentIds,
       },
     })
     .json();


### PR DESCRIPTION
## 설명

<!--
해당 Pull Request에 대한 설명을 작성합니다.

ex)
백엔드와 소셜 로그인을 연동하는 작업을 진행했습니다.
 -->

Context Menu에서 Duplicate 버튼을 통해 복제하는 기능을 구현했습니다.
추가로 컨텐츠 수정 시 color도 보낼 수 있게 구현했습니다.

## 작업내용

<!--
해당 Pull Request에서 진행했던 내용들을 작성합니다.

ex)
- [x] 카카오 로그인
- [x] 구글 로그인
 -->

- [x] 우클릭 시 Duplicate 버튼을 통해 복제 기능 구현
- [x] 컨텐츠 수정 시 color도 보낼 수 있게 구현

## 참고(선택)

<!--
리뷰어가 확인해주어야 하는 부분에 대해 작성합니다.

ex)
- 카카오 로그인 정상 작동하는지 확인 후 코멘트 부탁드립니다.
 -->

## 스크린샷(선택)

<!--
구현한 내용에 대한 스크린샷을 첨부합니다.
 -->

### 색상 메뉴
<img width="1822" height="1186" alt="스크린샷 2025-12-23 오후 4 52 30" src="https://github.com/user-attachments/assets/05dec95e-f023-466a-84cc-76e5f970f013" />

### 색상 선택 시
<img width="1822" height="1186" alt="스크린샷 2025-12-23 오후 4 52 41" src="https://github.com/user-attachments/assets/033a06d7-1b5d-4c8f-af5d-a79d7f50446e" />


## 메모(선택)

 <!--
해당 Pull Request에 대한 메모를 작성합니다.

ex)
- 추후 디벨롭 예정입니다.
 -->
디자인상 사용자 스티커는 선택할 수 있는 영역이 없기 때문에 현재 복제 기능은 컨텐츠 스티커에 대해서만 했습니다.
추후 디자인이 수정되면 사용자 스티커도 복제할 수 있도록 기능 수정하겠습니다.

## 연관 이슈

<!--
진행했던 이슈의 번호를 입력합니다.

ex)
resolved #64 
-->

resolved #64 
